### PR TITLE
Misspleling in module 1fichier.sh

### DIFF
--- a/1fichier.sh
+++ b/1fichier.sh
@@ -347,7 +347,7 @@ MODULE_1FICHIER_PROBE_OPTIONS=""
     REQ_OUT=c
 
     if [[ $REQ_IN = *f* ]]; then
-        if [[ $FILE_NALE ]]; then
+        if [[ $FILE_NAME ]]; then
             echo "$FILE_NAME"
             REQ_OUT="${REQ_OUT}f"
         else


### PR DESCRIPTION
This typo was reported by a debian user - see [BTS#780311](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=780311).