### PR TITLE
Do plowlist work again with multiup_org

### DIFF
--- a/multiup_org.sh
+++ b/multiup_org.sh
@@ -136,7 +136,7 @@ multiup_org_upload() {
 # $2: recurse subfolders (ignored here)
 # stdout: list of links
 multiup_org_list() {
-    local -r URL=$(replace '/miror/' '/download/' <<<"$1")
+    local -r URL=$(replace '/download/' '/en/mirror/' <<<"$1")
     local -r BASE_URL='http://www.multiup.org'
     local COOKIE_FILE PAGE LINK LINKS NAMES
 


### PR DESCRIPTION
Hello,

Simple upload link with the website or plowup is given so:
http://www.multiup.org/download/XXX/FILENAME.ext

So I replace only download with en/mirror so we come on the page with the links.

I'm not sure about the rest of the code (cookie file, ...)
But it work with only this change.