### PR TITLE
mediafire (download): upstream updated

### DIFF
--- a/mediafire.sh
+++ b/mediafire.sh
@@ -299,6 +299,9 @@ mediafire_download() {
 
         captcha_ack $ID
         log_debug 'Correct captcha'
+
+        # After resolving captcha we are redirected to an error page, so once again load a proper page.
+        PAGE=$(curl -b "$COOKIE_FILE" "$URL" | break_html_lines) || return
     fi
 
     # Check for password protected link


### PR DESCRIPTION
After resolving captcha we are redirected to an error page, so once
again load a proper page. This change is strongly related and probably
fixes mcrapet/plowshare#14.

Extensively tested with this list of test files:
```
http://www.mediafire.com/download/6yy0i251xks40a8/Test_file_5MB.zip
http://www.mediafire.com/download/gbu13pdexeuf81m/Test_file_10MB.zip
http://www.mediafire.com/download/b9rr63o4nn0jgqj/Test_file_15MB.zip
http://www.mediafire.com/download/0kiv6b1l3hxsdll/Test_file_20MB.zip
http://www.mediafire.com/download/1ka2a22o03b6h46/Test_file_25MB.zip
http://www.mediafire.com/download/aegr29cmoncc7i5/Test_file_30MB.zip
http://www.mediafire.com/download/p5u6sf6n3fdju04/Test_file_35MB.zip
http://www.mediafire.com/download/pxch4aq4yyu37um/Test_file_40MB.zip
http://www.mediafire.com/download/9uexydaz5a83b4n/Test_file_45MB.zip
http://www.mediafire.com/download/l5ysut7qmi17yxc/Test_file_50MB.zip
```
Note: Captcha is triggered after several successful downloads.