### PR TITLE
Update zippyshare.sh to fix Javascript error

### DIFF
--- a/zippyshare.sh
+++ b/zippyshare.sh
@@ -153,7 +153,7 @@ zippyshare_download() {
           }
         };
         $JS
-        print(elts['fimage'].href);" | javascript) || return
+        console.log(elts['fimage'].href);" | javascript) || return
 
     FILE_URL="$(basename_url "$URL")$PART_URL"
 

--- a/zippyshare.sh
+++ b/zippyshare.sh
@@ -153,7 +153,11 @@ zippyshare_download() {
           }
         };
         $JS
-        console.log(elts['fimage'].href);" | javascript) || return
+        if (typeof console === 'object' && typeof console.log === 'function') {
+          console.log(elts['fimage'].href);
+        } else {
+          print(elts['fimage'].href);
+        }" | javascript) || return
 
     FILE_URL="$(basename_url "$URL")$PART_URL"
 


### PR DESCRIPTION
print() function doesn't work in javascript, replaced it with console.log(). I was getting the following error before the change:

```
plowdown "http://www.zippyshare.com/v/______/file.html"
Starting download (zippyshare): http://www.zippyshare.com/v/______/file.html

/tmp/plowdown.18044.28293.js:22
        print(elts['fimage'].href);
        ^
ReferenceError: print is not defined
    at Object.<anonymous> (/tmp/plowdown.18044.28293.js:22:9)
    at Module._compile (module.js:446:26)
    at Object..js (module.js:464:10)
    at Module.load (module.js:353:32)
    at Function._load (module.js:311:12)
    at Array.0 (module.js:484:10)
    at EventEmitter._tickCallback (node.js:190:39)
```