### PR TITLE
Add missing contributors

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,18 +1,22 @@
 Alex Rea <amplitude@gmail.com>
 Antoine Girard <sapk@sapk.fr>
+Arnau Sanchez <tokland@gmail.com>
 Baptiste <baptiste.brun@gmail.com>
 Chu Chong Meng Steven <chu.chongmeng@gmail.com>
 Fabiano Francesconi <fabiano.francesconi@gmail.com>
 Golam Sarwar <gsbabil@gmail.com>
 Hervé <test.drive@gmail.com>
+idleloop <idleloop@yahoo.com>
 Jan <krompospeed@googlemail.com>a
-Jason <stone.bronson@gmail.com
+Jason <stone.bronson@gmail.com>
+ljsdoug <sdoug@inbox.com>
 Maurus Cuelenaere <mcuelenaere@gmail.com>
 Nicolas Michaux <nicolas@michaux.homelinux.org>
 Pavel Alexeev <Pahan@hubbitus.info>
 Petr Pulpán <Pulpan3@gmail.com>
 pink <ciasoms@gmail.com>
 ? <poomex.pl@gmail.com>
+Raziel-23 <venom23@runbox.com>
 Ryan <ryan.b.shaw@gmail.com>
 Soonbesleeping <soonbesleeping@gmail.com>
 StalkR <stalkr@stalkr.net>


### PR DESCRIPTION
The names are from the licenses of various files in this repository, and the emails are from the git commit history (and so are already public information distributed with this repository).