### PR TITLE
Add missing contributors

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -2,6 +2,7 @@ Alex Rea <amplitude@gmail.com>
 Antoine Girard <sapk@sapk.fr>
 Arnau Sanchez <tokland@gmail.com>
 Baptiste <baptiste.brun@gmail.com>
+Ben Zho <0xbzho@gmail.com>
 Chu Chong Meng Steven <chu.chongmeng@gmail.com>
 Fabiano Francesconi <fabiano.francesconi@gmail.com>
 Golam Sarwar <gsbabil@gmail.com>
@@ -12,6 +13,7 @@ Jason <stone.bronson@gmail.com>
 ljsdoug <sdoug@inbox.com>
 Maurus Cuelenaere <mcuelenaere@gmail.com>
 Nicolas Michaux <nicolas@michaux.homelinux.org>
+Oscar Padilla (dataoscar) <padillao@gmail.com>
 Pavel Alexeev <Pahan@hubbitus.info>
 Petr Pulpán <Pulpan3@gmail.com>
 pink <ciasoms@gmail.com>


### PR DESCRIPTION
In updating the debian packaging, I noticed a couple of new contributors missing from this list. Contact details and real names were found from the publicly available commit data.