### PR TITLE
Add git mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,12 @@
+Calvin Spencer Kwok <retsamff@gmail.com>
+capkokoon <cap.kokoon@gmail.com> <capkokoon@users.noreply.github.com>
+David Kurz <MDXDave@users.noreply.github.com>
+GaspardT <spirou91@hotmail.com> <Fullmono@users.noreply.github.com>
+idlelop <idleloop@yahoo.com>
+ljsdoug <sdoug@inbox.com> <ljsdoug@users.noreply.github.com>
+<mcrapet@gmail.com> <mcrapet@users.noreply.github.com>
+Oscar Padilla <padillao@gmail.com>
+<tapiwa@munzwa.tk> <tkmunzwa@gmail.com>
+<tokland@gmail.com> <pyarnau@gmail.com>
+Valérian Rousset <tharvik@users.noreply.github.com>
+Vitaly Shukela <vi0oss@gmail.com>


### PR DESCRIPTION
This file is used by [git-shortlog](https://git-scm.com/docs/git-shortlog) to tidy up the author and email information in the commit authorship data. This will make it easier to check contributions using `git shortlog -sne` for updating `CONTRIBUTORS` etc.