### PR TITLE
openload: Grab fid from URL if we use embed link

### DIFF
--- a/openload.sh
+++ b/openload.sh
@@ -80,8 +80,14 @@ openload_download() {
     local FILE_ID FILE_NAME FILE_URL
     local DL_TICKET CAPTCHA_URL
 
-    PAGE=$(curl -L "$URL") || return
-    FILE_ID=$(parse 'fid=' '"\(.*\)"' <<< "$PAGE") || return
+    # Take FILE_ID from URL if we use embed link
+    if match 'embed' "$URL" ; then
+      log_debug 'Grab FILE_ID from URL because we use embed link that must finish with /'
+      FILE_ID=$(parse '.' 'embed/\(.*\)/' <<< "$URL") || return
+    else
+      PAGE=$(curl -L "$URL") || return
+      FILE_ID=$(parse 'fid=' '"\(.*\)"' <<< "$PAGE") || return
+    fi
     log_debug "FILE_ID: $FILE_ID"
 
     # Request a download ticket


### PR DESCRIPTION
Hello,
It fixes https://github.com/mcrapet/plowshare-modules-legacy/issues/141

But I'm not really happy that I force the embed link to have '/' at the end.
I don't find how allow in parse to have or not a end with '/'.

The other idea was to take all the string after embed and remove the '/' if it was there but I not found it really nice.