### PR TITLE
Fix #191 : uptobox : take into account a small ui changes

### DIFF
--- a/uptobox.sh
+++ b/uptobox.sh
@@ -99,7 +99,7 @@ uptobox_download() {
         PAGE=$(curl -b "$COOKIE_FILE" "$BASE_URL/?op=my_account") || return
 
         # Opposite is: 'Upgrade to premium';
-        if match 'Renew premium' "$PAGE"; then
+        if match 'Renew Premium' "$PAGE"; then
             local DIRECT_URL
             PREMIUM=1
             DIRECT_URL=$(curl -I -b "$COOKIE_FILE" "$URL" | grep_http_header_location_quiet)


### PR DESCRIPTION
Proof with a premium account : 
```
$ plowdown http://uptobox.com/5ptsfgkkk9ha
Output directory: /tmp
uptobox: take --auth option from configuration file
Starting download (uptobox): http://uptobox.com/5ptsfgkkk9ha
Starting login process: XXXXX/************
File URL: https://www90.uptobox.com/dl/AAafkqj_se8VeidpgybvCmYAkEfFpxxzb46Na0jFJd1XSs7r5506a_UW31mxXnIMOowFeUAflmRF8-ysWT6aZotjl24Rq6x9_v2iNzx3umRTPOZ019bbzBEi6Om-Qz6DSqDwuTpzeYviuBxMGtBNFQ/LICENSE
Filename: LICENSE
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 35147  100 35147    0     0   193k      0 --:--:-- --:--:-- --:--:--  193k
/tmp/LICENSE
```