### PR TITLE
ulozto: New domain: ulozto.cz.

### DIFF
--- a/uloz_to.sh
+++ b/uloz_to.sh
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Plowshare.  If not, see <http://www.gnu.org/licenses/>.
 
-MODULE_ULOZ_TO_REGEXP_URL='https\?://\(www\.\)\?\(ulozto\.net\|uloz\.to\|ulozto\.sk\|zachowajto\.pl\)/'
+MODULE_ULOZ_TO_REGEXP_URL='https\?://\(www\.\)\?\(ulozto\.net\|uloz\.to\|ulozto\.cz\|ulozto\.sk\|zachowajto\.pl\)/'
 
 MODULE_ULOZ_TO_DOWNLOAD_OPTIONS=""
 MODULE_ULOZ_TO_DOWNLOAD_RESUME=yes


### PR DESCRIPTION
Czech variant of uloz.to switched to ulozto.cz as a default.

This PR adds this domain to the list.

Solves:
```
No module found, try simple redirection
Skip: no module for URL (https://ulozto.cz)
```