### PR TITLE
successive download interval rapidgator premium

### DIFF
--- a/rapidgator.sh
+++ b/rapidgator.sh
@@ -291,6 +291,8 @@ rapidgator_download() {
 
     # If this is a premium download, we already have the download link
     if [ "$ACCOUNT" = 'premium' ]; then
+        MODULE_RAPIDGATOR_DOWNLOAD_SUCCESSIVE_INTERVAL=0
+        
         # Consider errors (enforced limits) which only occur for premium users
         # You have reached quota of downloaded information for premium accounts
         if match 'reached quota of downloaded information' "$HTML"; then


### PR DESCRIPTION
The "MODULE_RAPIDGATOR_DOWNLOAD_SUCCESSIVE_INTERVAL" variable should be set to zero when user is logged into premium account.