### PR TITLE
Show errors on up2box

### DIFF
--- a/uptobox.sh
+++ b/uptobox.sh
@@ -52,12 +52,10 @@ uptobox_login() {
         log_debug 'Successfully logged in'
         return 0
     fi
-
     # Try to parse error
-    ERR=$(parse_tag_quiet 'class="err"' 'font' <<< "$LOGIN_RESULT")
-    [ -n "$ERR" ] || ERR=$(parse_tag_quiet "class='err'" 'div' <<< "$LOGIN_RESULT")
+    ERR=$(parse_all_tag_quiet 'class="errors mb-3"' 'li' <<< "$LOGIN_RESULT")
+    [ -n "$ERR" ] || ERR=$(parse_all_tag_quiet "class='errors mb-3'" 'li' <<< "$LOGIN_RESULT")
     [ -n "$ERR" ] && log_error "Unexpected remote error: $ERR"
-
     return $ERR_LOGIN_FAILED
 }
 


### PR DESCRIPTION
I  parse correctly the errors showed:

```
Starting download (uptobox): https://uptobox.com/c2h7k0m6rx0s
Starting login process: XXXX/******
Unexpected remote error: We detected that en email has already been sent to you. Please check your inbox
You are trying to log in from a different country, please check your mailbox to allow the connection.
Login process failed. Bad username/password or unexpected content
```
