### PR TITLE
Fix to download url path

### DIFF
--- a/bayimg.sh
+++ b/bayimg.sh
@@ -79,7 +79,7 @@ bayimg_upload() {
 
     FILE_URL=$(parse_attr 'image-setting' href <<< "$PAGE") || return
 
-    echo "http:$FILE_URL"
+    echo "http://bayimg.com$FILE_URL"
     echo
     echo "$ADMIN_CODE"
 }


### PR DESCRIPTION
The download path is now rendered as a relative url in the Bayimg page source, code amended to include the hostname.