### PR TITLE
mediafire.sh: fix

### DIFF
--- a/mediafire.sh
+++ b/mediafire.sh
@@ -193,20 +193,6 @@ mediafire_check_folder() {
     return $ERR_BAD_COMMAND_LINE
 }
 
-mediafire_get_ofuscated_link() {
-    local VAR=$1
-    local I N C R
-
-    I=0
-    N=${#VAR}
-    while (( I < N )); do
-        C=$((16#${VAR:$I:2} + 0x18))
-        R="$R"$(printf \\$(($C/64*100+$C%64/8*10+$C%8)))
-        (( I += 2 ))
-    done
-    echo "$R"
-}
-
 # Output a mediafire file download URL
 # $1: cookie file
 # $2: mediafire.com url
@@ -330,13 +316,9 @@ mediafire_download() {
         PAGE=$(curl -b "$COOKIE_FILE" "$URL" | break_html_lines) || return
     fi
 
-    JS_VAR=$(echo "$PAGE" | parse 'function[[:space:]]*_' '"\(.\+\)";' 1)
+    DL_URL=$(echo "$PAGE" | parse 'input popsok' '"\([^"]\+\)"' 2)
 
-    # extract + output download link + file name
-    mediafire_get_ofuscated_link "$JS_VAR" | parse_attr href || return
-    if ! parse_attr 'og:title' 'content' <<< "$PAGE"; then
-        parse_tag 'title' <<< "$PAGE" || return
-    fi
+    echo "$DL_URL"
 }
 
 # Static function. Proceed with login using official API


### PR DESCRIPTION
Fixing failure from what seems to be obsolete parsing (file is 3 years old):
```
parse failed (sed): "/function[[:space:]]*_/ s/^.*"\(.\+\)";.*$/\1/p" (skip 1)
Failed inside mediafire_download(), line 333, mediafire.sh
parse_attr failed (sed): "/href/ href="
Failed inside mediafire_download(), line 336, mediafire.sh
```

Parsing is made a lot easier now and seems to work with `/file/$FILE_ID/*` URLs at least for me.
I'm not sure if the other paths are still intact though. For a trial account upload I got only such URLs.
I left the other checks though they may be obsolete too by now.